### PR TITLE
アイコン一覧の取得方法を変更

### DIFF
--- a/src/app/api/icons/slugs/route.ts
+++ b/src/app/api/icons/slugs/route.ts
@@ -1,0 +1,31 @@
+import * as fs from "fs";
+import { NextRequest, NextResponse } from "next/server";
+import { IconData, getIconDataPath } from 'simple-icons/sdk';
+let icons: IconData[] = [];
+const loadIcons = () => {
+    try {
+        const data = fs.readFileSync(getIconDataPath("node_modules/simple-icons"), { encoding: "utf8" });
+        const icons: IconData[] = JSON.parse(data)["icons"];
+        return icons;
+    }
+    catch (err) {
+        console.error(err);
+        return [];
+    }
+}
+
+loadIcons();
+
+export async function GET(request: NextRequest) {
+    const headers = new Headers();
+    headers.set('Cache-Control', 's-maxage=31536000, stale-while-revalidate');
+
+    if (icons.length == 0) {
+        const load = fs.readFileSync(getIconDataPath("node_modules/simple-icons"), { encoding: "utf8" });
+        icons = JSON.parse(load)["icons"];
+    }
+
+    headers.set('Content-Type', 'application/json');
+    return NextResponse.json(icons, { status: 200, headers });
+}
+

--- a/src/utils/icon.ts
+++ b/src/utils/icon.ts
@@ -1,8 +1,12 @@
 import * as simpleIcons from 'simple-icons';
 
+export const getIconSlugs = () => {
+    return Object.keys(simpleIcons);
+}
+
 export const getIcon = (slug: string) => {
     if (!slug) return null;
-    const replace_slug = slug.toLowerCase().replaceAll(' ', 'plus').replaceAll('+', 'plus').replaceAll('.', 'dot');
+    const replace_slug = slug.toLowerCase().replaceAll(' ', '').replaceAll('+', 'plus').replaceAll('.', 'dot');
     const iconKeys = 'si' + replace_slug.charAt(0).toUpperCase() + replace_slug.slice(1);
     if (iconKeys in simpleIcons) {
         return (simpleIcons as any)[iconKeys];


### PR DESCRIPTION
## 概要
アイコン一覧の取得方法を変更し、データの読み込み効率を上げる

## 変更点
- simple-iconsの全インポートを削除
- タイトル一覧を取得できるエンドポイントの追加
- タイトルからslugにする処理の作成

## 関連Issue
#1 